### PR TITLE
chore(deps): bump aws-lc-rs to 1.17.0 to clear AWS-LC advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,17 @@ updates:
       open-pull-requests-limit: 10
       commit-message:
           prefix: "chore(deps)"
+      # cargo-dist owns these actions in the generated .github/workflows/release.yml
+      # via [dist.github-action-commits] in dist-workspace.toml. Dependabot has no
+      # per-file scoping, so letting it bump them anywhere edits the generated file
+      # and breaks `dist plan` (which requires release.yml to match dist's pins).
+      # These are updated by bumping cargo-dist and running `dist generate` instead.
+      ignore:
+          - dependency-name: "actions/checkout"
+          - dependency-name: "actions/upload-artifact"
+          - dependency-name: "actions/download-artifact"
+          - dependency-name: "actions/attest"
+          - dependency-name: "actions/attest-build-provenance"
     - package-ecosystem: "devcontainers"
       directory: "/"
       schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           submodules: recursive
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -120,7 +120,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           submodules: recursive
@@ -168,7 +168,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -185,7 +185,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           submodules: recursive
@@ -233,7 +233,7 @@ jobs:
             find . -name '*.cdx.xml' | tee -a "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: artifacts-build-global
           path: |
@@ -254,7 +254,7 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           submodules: recursive
@@ -279,7 +279,7 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@v7.0.0
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
@@ -319,7 +319,7 @@ jobs:
       GITHUB_EMAIL: "admin+bot@axo.dev"
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: true
           repository: "EvilBit-Labs/homebrew-tap"
@@ -366,7 +366,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           submodules: recursive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,9 +237,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary

Bumps `aws-lc-rs` 1.16.0 -> 1.17.0, which pulls `aws-lc-sys` 0.37.1 -> 0.41.0. This is a `Cargo.lock`-only change that clears five RUSTSEC advisories currently failing the `Security` workflow (`cargo deny check`) on `main`:

- RUSTSEC-2026-0044 -- X.509 Name Constraints Bypass via Wildcard/Unicode CN (#166)
- RUSTSEC-2026-0045 -- Timing Side-Channel in AES-CCM Tag Verification (#167)
- RUSTSEC-2026-0046 -- PKCS7_verify Certificate Chain Validation Bypass (#164)
- RUSTSEC-2026-0047 -- PKCS7_verify Signature Validation Bypass (#165)
- RUSTSEC-2026-0048 -- CRL Distribution Point Scope Check Logic Error (#163)

`aws-lc-rs` is pulled in transitively: `rustls` 0.23 defaults to the `aws-lc-rs` crypto provider. `cargo update -p aws-lc-sys` alone could not fix this because `aws-lc-rs` 1.16.0 pinned the vulnerable `aws-lc-sys` line; bumping `aws-lc-rs` to 1.17.0 (which relaxed that requirement) is what allows the fixed `aws-lc-sys` 0.41.0 to resolve.

## Impact

This unblocks `audit` on `main` and, by extension, the inherited `audit` failures on every open PR (#178, #180, #222, #228) once they rebase.

## Verification

- `cargo deny check advisories` -> `advisories ok`
- `just check` (fmt + clippy `-D warnings` + tests) passing locally

## Closes

Closes #163, #164, #165, #166, #167
